### PR TITLE
Update README with the correct config settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ class SculpinKernel extends \Sculpin\Bundle\SculpinBundle\HttpKernel\AbstractKer
 sculpin_scss:
 
     # The formatter to use
-    formatter_class: 'Leafo\\ScssPhp\\Formatter\\Compressed'
+    formatter_class: 'Leafo\ScssPhp\Formatter\Compressed'
     extensions: ["scss"]
     files: ["assets/css/style.scss"]
 ```


### PR DESCRIPTION
Using the double backslash for FQCN of the Formatter, the composer autoloader can't find the class. If you just use single backslashes, it works!

/cc @ursulaclarke